### PR TITLE
added ability to toggle uglify mangle names

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,8 @@
 exports.defaults = function() {
   return {
     minifyJS: {
-      exclude:[/\.min\./]
+      exclude:[/\.min\./],
+      mangleNames: true
     }
   };
 };
@@ -12,11 +13,13 @@ exports.defaults = function() {
 exports.placeholder = function () {
   var ph = "\n\n  minifyJS:                     # Configuration for minifying/cleaning js using the\n" +
      "                                # --minify flag\n" +
-     "    exclude:[/\\.min\\./]         # List of string paths and regexes to match files to exclude\n" +
+     "    exclude:[/\\.min\\./]       # List of string paths and regexes to match files to exclude\n" +
      "                                # when running minification. Any path with \".min.\" in its name,\n" +
      "                                # is assumed to already be minified and is ignored by default.\n" +
      "                                # Paths can be relative to the watch.compiledDir, or absolute. \n" +
-     "                                # Paths are to compiled files,  so '.js' rather than '.coffee'\n\n";
+     "                                # Paths are to compiled files,  so '.js' rather than '.coffee'\n\n" +
+     "    mangleNames:true            # Controls whether or not UglifyJS is allowed to reduce names of\n " +
+     "                                # local variables and functions to single letters";
 
   return ph;
 };
@@ -26,5 +29,6 @@ exports.validate = function( config, validators )  {
   if ( validators.ifExistsIsObject( errors, "minifyCSS config", config.minifyJS ) ) {
     validators.ifExistsFileExcludeWithRegexAndString( errors, "minifyJS.exclude", config.minifyJS, config.watch.compiledDir );
   }
+  validators.ifExistsIsBoolean(errors, "minifyJS.mangleNames", config.minifyJS.mangleNames);
   return errors;
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -80,7 +80,10 @@ var _performJSMinify = function (config, file) {
     var compressedAst = toplevelAst.transform( compressor );
     compressedAst.figure_out_scope();
     compressedAst.compute_char_frequency();
-    compressedAst.mangle_names( {except:[ "require", "requirejs", "define", "exports", "module" ]} );
+    if(config.minifyJS.mangleNames){
+      compressedAst.mangle_names( {except:[ "require", "requirejs", "define", "exports", "module" ]} );
+    }
+
     compressedAst.print( stream );
     var code = stream + "";
 


### PR DESCRIPTION
Hey David, 

When optimizing / minimizing our code we need to preserve variable names. This is primarily because use use an evented architecture and need to make sure when we talk about an event like "Classname::method" the classname isn't minimized to another variable in our codebase.

To address this issues I added a flag to toggle the manglenames option to minify-js. 
